### PR TITLE
Fix MustCompile panic with user-supplied CLI name in parser

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -61,11 +61,15 @@ func CLIOutput(ctx *types.Context, cliName string) (string, error) {
 		output, _ = io.ReadAll(stderr)
 	}
 
-	return CLIVersion(ctx, baseName, string(output)), nil
+	version, err := CLIVersion(ctx, baseName, string(output))
+	if err != nil {
+		return "", err
+	}
+	return version, nil
 }
 
 //nolint:funlen
-func CLIVersion(ctx *types.Context, cliName, output string) string {
+func CLIVersion(ctx *types.Context, cliName, output string) (string, error) {
 	floatRegex := `\d+\.\d+`
 	floatWithTrailingLetterRegex := `[\d.]*\w`
 	intRegex := `\d*`
@@ -133,7 +137,11 @@ func CLIVersion(ctx *types.Context, cliName, output string) string {
 			semverRegex, vStringWithTrailingLetterRegex, floatWithTrailingLetterRegex,
 			vStringRegex, optimisticRegex, floatRegex))
 	} else {
-		versionRegex = regexp.MustCompile(`(?i)` + cliName + `\s+(.*)\b`)
+		var err error
+		versionRegex, err = regexp.Compile(`(?i)` + regexp.QuoteMeta(cliName) + `\s+(.*)\b`)
+		if err != nil {
+			return "", fmt.Errorf("invalid CLI name for regex: %w", err)
+		}
 	}
 
 	matches := versionRegex.FindAllStringSubmatch(output, -1)
@@ -145,5 +153,5 @@ func CLIVersion(ctx *types.Context, cliName, output string) string {
 	}
 	output = strings.TrimRight(output, "\n")
 
-	return output
+	return output, nil
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -139,9 +139,11 @@ bug reports using http://www.info-zip.org/zip-bug.html; see README for details.`
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test[1], parser.CLIVersion(
+		got, err := parser.CLIVersion(
 			&ctx, test[0], test[2],
-		))
+		)
+		assert.NoError(t, err)
+		assert.Equal(t, test[1], got)
 	}
 
 	{
@@ -152,9 +154,23 @@ bug reports using http://www.info-zip.org/zip-bug.html; see README for details.`
 		o, err := (parser.CLIOutput(ctx, "../testdata/bin/bad-version"))
 		assert.NoError(t, err)
 		assert.Equal(t, "X3v", o)
-		got := parser.CLIVersion(ctx, "../testdata/bin/bad-version", o)
+		got, err := parser.CLIVersion(ctx, "../testdata/bin/bad-version", o)
+		assert.NoError(t, err)
 		assert.Equal(t, "X3v", got)
 	}
+}
+
+func TestCLIVersionInvalidRegex(t *testing.T) {
+	t.Parallel()
+	ctx := &types.Context{
+		Context: context.Background(),
+	}
+	// A CLI name containing '(' is not in the known-regexen map and has more
+	// than one line of output, so it falls through to the fallback regex path.
+	// With regexp.QuoteMeta the parenthesis is escaped and Compile succeeds,
+	// returning the raw output unchanged rather than panicking.
+	_, err := parser.CLIVersion(ctx, "bad(name", "bad(name 1.2.3")
+	assert.NoError(t, err)
 }
 
 func TestCLIOutput(t *testing.T) {

--- a/security-findings.md
+++ b/security-findings.md
@@ -18,7 +18,7 @@ Identified by automated security review on 2026-04-23. Fix sequentially in discr
 ### 2. `MustCompile` panic in `parser/parser.go:136`
 User-supplied CLI name is interpolated directly into a regex and passed to `regexp.MustCompile`. An invalid regex (e.g. a name containing `(`) crashes the process.
 - **Fix:** Use `regexp.Compile` + `regexp.QuoteMeta`.
-- **Status:** Open
+- **Status:** Fixed
 
 ### 3. `ne` operator logic bug in `compare/compare.go:220`
 `ctx.Success` is set to a regex match result inside the `Ne` case, producing wrong exit codes for `ne` comparisons.


### PR DESCRIPTION
## Summary
- Replaces `regexp.MustCompile` with `regexp.Compile` for the user-supplied CLI name regex in `parser/parser.go`
- Applies `regexp.QuoteMeta` to the CLI name before interpolation — treats it as a literal string, preventing both panic on invalid regex syntax and ReDoS
- Propagates the compile error to callers

## Security
Fixes Important finding #2 from security review: a CLI name containing `(` (e.g. `is cli version "bad(name" gte 1`) caused `regexp.MustCompile` to panic and crash the process.

## Test plan
- [x] `TestCLIVersionInvalidRegex` — name containing `(` does not panic, returns gracefully
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)