### PR TITLE
Fix ne operator incorrectly mutating ctx.Success via regex side-effect

### DIFF
--- a/compare/compare.go
+++ b/compare/compare.go
@@ -204,7 +204,6 @@ func Versions( //nolint:cyclop
 	}
 }
 
-//nolint:cyclop
 func Strings(ctx *types.Context, operator, got, want string) (bool, error) {
 	maybeDebug(ctx, "strings", operator, got, want)
 

--- a/compare/compare.go
+++ b/compare/compare.go
@@ -218,14 +218,6 @@ func Strings(ctx *types.Context, operator, got, want string) (bool, error) {
 		}
 		return slices.Contains(wantList, got), nil
 	case ops.Ne:
-		matched, err := regexp.MatchString(want, got)
-		if err != nil {
-			return false, fmt.Errorf(`compare strings "%s" %s "%s"`, got, operator, want)
-		}
-		ctx.Success = matched
-		if operator == ops.Unlike {
-			ctx.Success = !matched
-		}
 		return got != want, nil
 	case ops.Like:
 		success, err := regexp.MatchString(want, got)

--- a/compare/compare_test.go
+++ b/compare/compare_test.go
@@ -267,6 +267,22 @@ func TestStrings(t *testing.T) {
 			Debug:   true,
 		},
 		{
+			Op:      ops.Ne,
+			Got:     "foo",
+			Want:    "bar",
+			Error:   false,
+			Success: true,
+			Debug:   false,
+		},
+		{
+			Op:      ops.Ne,
+			Got:     "foo",
+			Want:    "foo",
+			Error:   false,
+			Success: false,
+			Debug:   false,
+		},
+		{
 			Op:      ops.In,
 			Got:     "delboy trotter",
 			Want:    "delboy trotter, rodney trotter",

--- a/security-findings.md
+++ b/security-findings.md
@@ -23,7 +23,7 @@ User-supplied CLI name is interpolated directly into a regex and passed to `rege
 ### 3. `ne` operator logic bug in `compare/compare.go:220`
 `ctx.Success` is set to a regex match result inside the `Ne` case, producing wrong exit codes for `ne` comparisons.
 - **Fix:** Remove the side-effecting `ctx.Success` mutation from the `Ne` case.
-- **Status:** Open
+- **Status:** Fixed
 
 ### 4. Missing `cmd.Wait()` in `command/command.go:37` and `parser/parser.go:50`
 Zombie processes accumulate when `is` is invoked in a tight loop because `cmd.Wait()` is never called after `cmd.Start()`.


### PR DESCRIPTION
## Summary
- Removes erroneous `ctx.Success = matched` mutation from the `Ne` case in `compare/compare.go`
- Removes dead code: `operator == ops.Unlike` branch inside `Ne` that could never be reached
- The correct `return got != want, nil` was already there and is now the only statement in the case

## Security / Correctness
Fixes Important finding #3 from security review: `ne` comparisons were setting `ctx.Success` based on a regex match result rather than string inequality, producing incorrect exit codes in scripts using `is var X ne Y` or similar.

## Test plan
- [x] Regression tests: `"foo" ne "bar"` → success, `"foo" ne "foo"` → failure
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)