### PR TITLE
Add defer cmd.Wait() to prevent zombie process accumulation

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -37,6 +37,9 @@ func Output(cmd *exec.Cmd, stream string) (string, error) {
 		if err := cmd.Start(); err != nil {
 			return "", fmt.Errorf("starting command: %w", err)
 		}
+		// Wait releases OS process resources; defer ensures it runs after
+		// pipe reads complete, preventing zombie processes in tight loops.
+		defer cmd.Wait() //nolint:errcheck
 
 		output, err = io.ReadAll(pipe)
 		if err != nil {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -50,6 +50,9 @@ func CLIOutput(ctx *types.Context, cliName string) (string, error) {
 	if err := cmd.Start(); err != nil {
 		return "", fmt.Errorf("starting command: %w", err)
 	}
+	// Wait releases OS process resources; defer ensures it runs after
+	// pipe reads complete, preventing zombie processes in tight loops.
+	defer cmd.Wait() //nolint:errcheck
 
 	output, _ := io.ReadAll(stdout)
 	// ssh -V doesn't print to STDOUT?

--- a/security-findings.md
+++ b/security-findings.md
@@ -28,7 +28,7 @@ User-supplied CLI name is interpolated directly into a regex and passed to `rege
 ### 4. Missing `cmd.Wait()` in `command/command.go:37` and `parser/parser.go:50`
 Zombie processes accumulate when `is` is invoked in a tight loop because `cmd.Wait()` is never called after `cmd.Start()`.
 - **Fix:** Add `defer cmd.Wait()` after each successful `cmd.Start()`.
-- **Status:** Open
+- **Status:** Fixed
 
 ### 5. Integer overflow in `age/age.go:36`
 `value * unitMultiplier` can overflow on 32-bit systems for large inputs.


### PR DESCRIPTION
## Summary
- Adds `defer cmd.Wait()` after each successful `cmd.Start()` in `command/command.go` and `parser/parser.go`
- Ensures OS process resources are released after subprocess output is read
- `defer` placement guarantees pipes are fully drained before `Wait` is called

## Security / Correctness
Fixes Important finding #4 from security review: missing `cmd.Wait()` caused zombie processes to accumulate when `is` was invoked in a tight loop (e.g. inside a Makefile or monitoring script).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- Zombie accumulation is a kernel-level resource leak not easily observable in unit tests; the fix is verified by code inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)