### PR TITLE
Add bounds check to prevent integer overflow in age parsing

### DIFF
--- a/age/age.go
+++ b/age/age.go
@@ -33,6 +33,9 @@ func StringToDuration(val, rawUnit string) (*time.Duration, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%s does not appear to be an integer: %w", val, err)
 	}
+	if value < 1 || value > 36500 {
+		return nil, fmt.Errorf("value %d is out of range: must be between 1 and 36500", value)
+	}
 	durationString := fmt.Sprintf("%d%s", value*unitMultiplier, unit)
 	dur, err := time.ParseDuration(durationString)
 	if err != nil {

--- a/age/age_test.go
+++ b/age/age_test.go
@@ -1,12 +1,17 @@
-package age
+package age_test
 
 import (
 	"testing"
+
+	"github.com/oalders/is/age"
 )
 
 func TestStringToDuration(t *testing.T) {
+	t.Parallel()
+
 	t.Run("valid value succeeds", func(t *testing.T) {
-		dur, err := StringToDuration("10", "days")
+		t.Parallel()
+		dur, err := age.StringToDuration("10", "days")
 		if err != nil {
 			t.Fatalf("unexpected error for value 10: %v", err)
 		}
@@ -16,28 +21,32 @@ func TestStringToDuration(t *testing.T) {
 	})
 
 	t.Run("value above 36500 returns error", func(t *testing.T) {
-		_, err := StringToDuration("36501", "days")
+		t.Parallel()
+		_, err := age.StringToDuration("36501", "days")
 		if err == nil {
 			t.Fatal("expected error for value 36501, got nil")
 		}
 	})
 
 	t.Run("value below 1 returns error", func(t *testing.T) {
-		_, err := StringToDuration("0", "days")
+		t.Parallel()
+		_, err := age.StringToDuration("0", "days")
 		if err == nil {
 			t.Fatal("expected error for value 0, got nil")
 		}
 	})
 
 	t.Run("negative value returns error", func(t *testing.T) {
-		_, err := StringToDuration("-1", "days")
+		t.Parallel()
+		_, err := age.StringToDuration("-1", "days")
 		if err == nil {
 			t.Fatal("expected error for value -1, got nil")
 		}
 	})
 
 	t.Run("boundary value 36500 succeeds", func(t *testing.T) {
-		dur, err := StringToDuration("36500", "days")
+		t.Parallel()
+		dur, err := age.StringToDuration("36500", "days")
 		if err != nil {
 			t.Fatalf("unexpected error for boundary value 36500: %v", err)
 		}
@@ -47,7 +56,8 @@ func TestStringToDuration(t *testing.T) {
 	})
 
 	t.Run("boundary value 1 succeeds", func(t *testing.T) {
-		dur, err := StringToDuration("1", "hours")
+		t.Parallel()
+		dur, err := age.StringToDuration("1", "hours")
 		if err != nil {
 			t.Fatalf("unexpected error for boundary value 1: %v", err)
 		}

--- a/age/age_test.go
+++ b/age/age_test.go
@@ -1,0 +1,58 @@
+package age
+
+import (
+	"testing"
+)
+
+func TestStringToDuration(t *testing.T) {
+	t.Run("valid value succeeds", func(t *testing.T) {
+		dur, err := StringToDuration("10", "days")
+		if err != nil {
+			t.Fatalf("unexpected error for value 10: %v", err)
+		}
+		if dur == nil {
+			t.Fatal("expected non-nil duration")
+		}
+	})
+
+	t.Run("value above 36500 returns error", func(t *testing.T) {
+		_, err := StringToDuration("36501", "days")
+		if err == nil {
+			t.Fatal("expected error for value 36501, got nil")
+		}
+	})
+
+	t.Run("value below 1 returns error", func(t *testing.T) {
+		_, err := StringToDuration("0", "days")
+		if err == nil {
+			t.Fatal("expected error for value 0, got nil")
+		}
+	})
+
+	t.Run("negative value returns error", func(t *testing.T) {
+		_, err := StringToDuration("-1", "days")
+		if err == nil {
+			t.Fatal("expected error for value -1, got nil")
+		}
+	})
+
+	t.Run("boundary value 36500 succeeds", func(t *testing.T) {
+		dur, err := StringToDuration("36500", "days")
+		if err != nil {
+			t.Fatalf("unexpected error for boundary value 36500: %v", err)
+		}
+		if dur == nil {
+			t.Fatal("expected non-nil duration")
+		}
+	})
+
+	t.Run("boundary value 1 succeeds", func(t *testing.T) {
+		dur, err := StringToDuration("1", "hours")
+		if err != nil {
+			t.Fatalf("unexpected error for boundary value 1: %v", err)
+		}
+		if dur == nil {
+			t.Fatal("expected non-nil duration")
+		}
+	})
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -81,7 +81,7 @@ func TestCliAge(t *testing.T) {
 			Context: context.Background(),
 			Debug:   true,
 		}
-		cmd := CLICmd{Age: AgeCmp{command, ops.Lt, "100000", "days"}}
+		cmd := CLICmd{Age: AgeCmp{command, ops.Lt, "36500", "days"}}
 		err := cmd.Run(ctx)
 		assert.NoError(t, err)
 		assert.True(t, ctx.Success)

--- a/fso_test.go
+++ b/fso_test.go
@@ -27,7 +27,7 @@ func TestFSOLastModifiedTime(t *testing.T) {
 			Context: context.Background(),
 			Debug:   true,
 		}
-		cmd := FSOCmd{Age: AgeCmp{tmux, ops.Lt, "100000", "days"}}
+		cmd := FSOCmd{Age: AgeCmp{tmux, ops.Lt, "36500", "days"}}
 		err := cmd.Run(ctx)
 		assert.NoError(t, err)
 		assert.True(t, ctx.Success)

--- a/security-findings.md
+++ b/security-findings.md
@@ -33,7 +33,7 @@ Zombie processes accumulate when `is` is invoked in a tight loop because `cmd.Wa
 ### 5. Integer overflow in `age/age.go:36`
 `value * unitMultiplier` can overflow on 32-bit systems for large inputs.
 - **Fix:** Add a bounds check or cap after `strconv.Atoi`.
-- **Status:** Open
+- **Status:** Fixed
 
 ### 6. `ParseInt` base 0 in `battery.go:39`
 Base 0 accidentally accepts hex (`0x...`) and octal (`0...`) input from the user.


### PR DESCRIPTION
## Summary
- Adds a bounds check in `age/age.go` after `strconv.Atoi`: rejects values < 1 or > 36500 (100 years) with a descriptive error
- Prevents integer overflow from `value * unitMultiplier` on large inputs
- Updates two existing tests that used `"100000"` as a sentinel to use `"36500"`

## Security / Correctness
Fixes Important finding #5 from security review: unconstrained integer input could overflow on multiplication before being used as a duration.

## Test plan
- [x] Valid value (10) succeeds
- [x] Boundary values (1, 36500) succeed
- [x] Out-of-range values (0, -1, 36501) return errors
- [x] `go build ./...` and `go test ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)