### PR TITLE
Fix ParseInt to use base 10 for battery values

### DIFF
--- a/battery.go
+++ b/battery.go
@@ -36,7 +36,7 @@ func (r *BatteryCmd) Run(ctx *types.Context) error {
 		}
 		ctx.Success = ok
 	case int:
-		want, err := strconv.ParseInt(r.Val, 0, 32)
+		want, err := strconv.ParseInt(r.Val, 10, 0)
 		if err != nil {
 			return errors.Join(
 				errors.New("wanted result could not be converted to an integer"),

--- a/security-findings.md
+++ b/security-findings.md
@@ -38,7 +38,7 @@ Zombie processes accumulate when `is` is invoked in a tight loop because `cmd.Wa
 ### 6. `ParseInt` base 0 in `battery.go:39`
 Base 0 accidentally accepts hex (`0x...`) and octal (`0...`) input from the user.
 - **Fix:** Use base 10 (`strconv.ParseInt(r.Val, 10, strconv.IntSize)`).
-- **Status:** Open
+- **Status:** Fixed
 
 ---
 

--- a/test/no-battery.bats
+++ b/test/no-battery.bats
@@ -50,6 +50,12 @@ setup() {
     ./is battery state unlike char
 }
 
+@test "is battery count eq 0x0 fails with parse error (hex rejected)" {
+    run ./is battery count eq 0x0
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"wanted result could not be converted to an integer"* ]]
+}
+
 @test "is battery voltage eq 0 --debug" {
     ./is battery voltage eq 0 --debug
 }


### PR DESCRIPTION
## Summary
- Changes `strconv.ParseInt(r.Val, 0, 32)` to `strconv.ParseInt(r.Val, 10, 0)` in `battery.go`
- Base 10 rejects accidental hex (`0x1F`) and octal (`077`) input — only decimal integers are valid for battery values
- `bitSize 0` matches the platform's native `int` width, making the `int(want)` cast safe

## Security / Correctness
Fixes Important finding #6 from security review: base 0 accidentally accepted hex/octal user input, and bitSize 32 didn't match the platform's native int size.

## Test plan
- [x] BATS regression test: `is battery count eq 0x0` is rejected with a parse error
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)