### PR TITLE
Propagate io.ReadAll errors in parser instead of discarding them

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -51,14 +51,20 @@ func CLIOutput(ctx *types.Context, cliName string) (string, error) {
 		return "", fmt.Errorf("starting command: %w", err)
 	}
 
-	output, _ := io.ReadAll(stdout)
+	output, err := io.ReadAll(stdout)
+	if err != nil {
+		return "", fmt.Errorf("reading stdout: %w", err)
+	}
 	// ssh -V doesn't print to STDOUT?
 	if len(output) == 0 {
 		if ctx.Debug {
 			log.Printf("Running: %s %s and checking STDERR\n", args[0], args[1])
 		}
 
-		output, _ = io.ReadAll(stderr)
+		output, err = io.ReadAll(stderr)
+		if err != nil {
+			return "", fmt.Errorf("reading stderr: %w", err)
+		}
 	}
 
 	return CLIVersion(ctx, baseName, string(output)), nil

--- a/security-findings.md
+++ b/security-findings.md
@@ -62,4 +62,4 @@ Acts as a file-existence oracle in restricted shell environments via exit code.
 ### 10. Silently discarded `io.ReadAll` errors in `parser/parser.go`
 Errors from reading subprocess stdout/stderr are discarded with `_`, masking failures.
 - **Fix:** Propagate errors or log them when debug mode is active.
-- **Status:** Open
+- **Status:** Fixed


### PR DESCRIPTION
## Summary
- Checks and returns errors from both `io.ReadAll` calls in `parser/parser.go`
- Previously both were silently discarded with `_`, causing the function to proceed with empty output on pipe read failures (subprocess killed, I/O error, context cancelled)

## Security / Correctness
Fixes Minor finding #10 from security review: silently discarded pipe read errors masked subprocess failures, causing the tool to return exit code 1 (no match) rather than reporting the actual error condition.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)